### PR TITLE
Potential fix for code scanning alert no. 6: Prototype-polluting assignment

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -2695,7 +2695,9 @@ d-citation-list .references .title {
           var rest = grammar.rest;
           if (rest) {
             for (var token in rest) {
-              grammar[token] = rest[token];
+              if (token !== '__proto__' && token !== 'constructor' && token !== 'prototype') {
+                grammar[token] = rest[token];
+              }
             }
 
             delete grammar.rest;


### PR DESCRIPTION
Potential fix for [https://github.com/leekaize/leekaize-dot-com/security/code-scanning/6](https://github.com/leekaize/leekaize-dot-com/security/code-scanning/6)

To fix the prototype pollution vulnerability, we need to ensure that the `grammar` object is not assigned any properties that could modify `Object.prototype`. This can be achieved by checking the keys before assignment and rejecting any keys that could lead to prototype pollution.

The best way to fix this problem without changing existing functionality is to add a check before assigning properties from `rest` to `grammar`. We will reject keys like `__proto__`, `constructor`, and `prototype`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
